### PR TITLE
fix: gitpod link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 - [Browser-based setup with GitPod](https://gitpod.io/from-referrer/)
   - GitPod provides a cloud-based development environment similar to VS Code  
-  - Requires a login with Github
+  - Requires a login with GitHub
   - **Note**: GitPod may have accessibility issues
 - [Download a zip file for local setup](https://github.com/testing-accessibility/workshop-design-people-skills/archive/refs/heads/main.zip)
 - Clone this Git repo for local setup (see instructions below)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 <!-- prettier-ignore-start -->
 [![GPL 3.0 License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 <!-- prettier-ignore-end -->
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@
 
 ## Options for working with this material
 
-- [Browser-based setup with GitPod](https://testingaccessib-workshop-abielzjxum9.ws-us39a.gitpod.io)
-  - Note: GitPod may have accessibility issues
+- [Browser-based setup with GitPod](https://gitpod.io/#https://github.com/testing-accessibility/workshop-design-people-skills)
+  - GitPod provides a cloud-based development environment similar to VS Code  
+  - Requires a login with Github
+  - **Note**: GitPod may have accessibility issues
 - [Download a zip file for local setup](https://github.com/testing-accessibility/workshop-design-people-skills/archive/refs/heads/main.zip)
 - Clone this Git repo for local setup (see instructions below)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## Options for working with this material
 
-- [Browser-based setup with GitPod](https://gitpod.io/#https://github.com/testing-accessibility/workshop-design-people-skills)
+- [Browser-based setup with GitPod](https://gitpod.io/from-referrer/)
   - GitPod provides a cloud-based development environment similar to VS Code  
   - Requires a login with Github
   - **Note**: GitPod may have accessibility issues


### PR DESCRIPTION
The gitpod link in the readme was directly to an instance. I've updated it with a link that will create an instance for the user instead.